### PR TITLE
Fixed the number of seconds in a day

### DIFF
--- a/app/Tick.php
+++ b/app/Tick.php
@@ -36,7 +36,7 @@ class Tick {
 			call_user_func($cb);
 		}
 
-		if (self::$second % 84600 == 0)
+		if (self::$second % 86400 == 0)
 			Tick::day();
 	} // function hour
 


### PR DESCRIPTION
Old value missed 30 minutes. `60*60*24 = 86400` in one day
